### PR TITLE
Embed YouTube Shorts in self-hosted post

### DIFF
--- a/data/blog/self-hosted.mdx
+++ b/data/blog/self-hosted.mdx
@@ -84,8 +84,9 @@ tags: ['Self-Hosted', 'HomeAssistant', 'No-Code']
 
 הנה שני סרטונים שאני עשיתי:
 
-- [אור חלש #ביתחכם #homeassistant - YouTube](https://youtube.com/shorts/VHtlTuWX0iM?feature=share)
-- [אין יותר להישאר בממ"ד בחושך כשיש אזעקה בשבת. ואפילו לא צריך שעון.#ביתחכם #homeassistant #אזעקה #שבת - YouTube](https://youtube.com/shorts/ZA3jPCTZ8Mc?feature=share)
+<YouTubeShort id="VHtlTuWX0iM" />
+
+<YouTubeShort id="ZA3jPCTZ8Mc" />
 
 <Note>
   מי שיתסכל בהגדרות המערכת שלי יראה שאני מריץ גם דפדפן בתוך קונטיינר 🤔 הסיבה היא שכדי שיהיה לי מסך

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const ContentSecurityPolicy = `
   media-src *.s3.amazonaws.com *.posthog.com;
   connect-src * *.posthog.com;
   font-src 'self' *.posthog.com;
-  frame-src giscus.app *.posthog.com github.com n8n-preview-service.internal.n8n.cloud app.cal.com;
+  frame-src giscus.app *.posthog.com github.com n8n-preview-service.internal.n8n.cloud app.cal.com www.youtube-nocookie.com;
 `
 
 const securityHeaders = [

--- a/src/components/MDXComponents.tsx
+++ b/src/components/MDXComponents.tsx
@@ -1,5 +1,6 @@
 import CalBooker from '@/components/CalBooker'
 import N8nDemo from '@/components/N8nDemo'
+import YouTubeShort from '@/components/YouTubeShort'
 import type { MDXComponents } from 'mdx/types'
 import BlogNewsletterForm from 'pliny/ui/BlogNewsletterForm'
 import Pre from 'pliny/ui/Pre'
@@ -19,4 +20,5 @@ export const components: MDXComponents = {
   Note,
   N8nDemo,
   CalBooker,
+  YouTubeShort,
 }

--- a/src/components/YouTubeShort.tsx
+++ b/src/components/YouTubeShort.tsx
@@ -1,0 +1,19 @@
+interface Props {
+  id: string
+}
+
+export default function YouTubeShort({ id }: Props) {
+  return (
+    <div className="flex justify-center my-4">
+      <iframe
+        src={`https://www.youtube-nocookie.com/embed/${id}`}
+        title="YouTube Short"
+        className="rounded-lg"
+        width="315"
+        height="560"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  )
+}

--- a/src/components/YouTubeShort.tsx
+++ b/src/components/YouTubeShort.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 export default function YouTubeShort({ id }: Props) {
   return (
-    <div className="flex justify-center my-4">
+    <div className="my-4 flex justify-center">
       <iframe
         src={`https://www.youtube-nocookie.com/embed/${id}`}
         title="YouTube Short"


### PR DESCRIPTION
## Summary

- Add a `YouTubeShort` MDX component that embeds Shorts using `www.youtube-nocookie.com` (privacy-enhanced mode) with a 9:16 vertical aspect ratio
- Register `YouTubeShort` in `MDXComponents.tsx` so it's available in any blog post
- Replace the two plain-text Short links in `self-hosted.mdx` with actual embedded players
- Add `www.youtube-nocookie.com` to the CSP `frame-src` directive so the iframes are allowed to load

## Why `YouTubeShort` component instead of a raw `<iframe>`?

The site already uses a custom-component pattern for embeds (e.g. `N8nDemo`, `CalBooker`). A dedicated component:
- Enforces correct 9:16 aspect ratio for all Shorts
- Keeps MDX clean — authors write `<YouTubeShort id="VHtlTuWX0iM" />` instead of a full iframe
- Uses `youtube-nocookie.com` consistently (no YouTube cookies until the user plays)

## Test plan

- [ ] Visit `/blog/self-hosted` — the two Home Assistant Shorts should be embedded and playable
- [ ] Check browser devtools for CSP errors (should be none for the YouTube iframes)
- [ ] Verify 9:16 vertical layout looks correct on both desktop and mobile

https://claude.ai/code/session_01E61FBYLww3e2wpxr6gMj4r

---
_Generated by [Claude Code](https://claude.ai/code/session_01E61FBYLww3e2wpxr6gMj4r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a YouTube Shorts embed component and updated blog posts to use native Shorts embeds for improved viewing.

* **Chores**
  * Updated content security policy to allow YouTube short embeds via the privacy-friendly domain, ensuring embeds display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->