### PR TITLE
Add RSS feed icon to social links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,6 +18,7 @@ export default function Footer() {
           <SocialIcon kind="threads" href={siteMetadata.threads} size={6} />
           <SocialIcon kind="mastodon" href={siteMetadata.mastodon} size={6} />
           <SocialIcon kind="bluesky" href={siteMetadata.bluesky} size={6} />
+          <SocialIcon kind="rss" href="/feed.xml" size={6} tooltip="RSS" />
         </div>
         <div className="mb-2 flex space-x-2 text-sm text-gray-500 dark:text-gray-400">
           <div>{siteMetadata.author}</div>

--- a/src/components/social-icons/icons.tsx
+++ b/src/components/social-icons/icons.tsx
@@ -100,6 +100,14 @@ export function Discord(svgProps: SVGProps<SVGSVGElement>) {
   )
 }
 
+export function Rss(svgProps: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...svgProps}>
+      <path d="M19.199 24C19.199 13.467 10.533 4.8 0 4.8V0c13.165 0 24 10.835 24 24h-4.801zM3.291 17.415c1.814 0 3.293 1.479 3.293 3.295 0 1.813-1.485 3.29-3.301 3.29C1.47 24 0 22.526 0 20.71s1.475-3.294 3.291-3.295zM15.909 24h-4.665c0-6.169-5.075-11.245-11.244-11.245V8.09c8.727 0 15.909 7.184 15.909 15.91z" />
+    </svg>
+  )
+}
+
 export function WhatsApp(svgProps: SVGProps<SVGSVGElement>) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...svgProps}>

--- a/src/components/social-icons/index.tsx
+++ b/src/components/social-icons/index.tsx
@@ -7,6 +7,7 @@ import {
   Linkedin,
   Mail,
   Mastodon,
+  Rss,
   Telegram,
   Threads,
   Twitter,
@@ -28,6 +29,7 @@ const components = {
   bluesky: Bluesky,
   discord: Discord,
   whatsapp: WhatsApp,
+  rss: Rss,
 }
 
 export type SocialKind = keyof typeof components


### PR DESCRIPTION
## Summary
Adds an RSS feed icon to the social media links displayed in the footer, allowing users to subscribe to the blog via RSS.

## Changes
- **icons.tsx**: Added new `Rss` SVG icon component with standard RSS feed symbol
- **index.tsx**: Exported the new `Rss` icon and registered it in the social icons component map
- **Footer.tsx**: Integrated RSS icon link pointing to `/feed.xml` with tooltip label

## Implementation Details
The RSS icon follows the same pattern as existing social icons (Discord, WhatsApp, etc.), using SVG with proper viewBox and accepting standard SVG props for styling and sizing. The footer link is hardcoded to `/feed.xml` with a tooltip for clarity.

https://claude.ai/code/session_012oHLE378TNYN4QNAoqTgn5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RSS feed social link icon to the footer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->