### PR TITLE
Index projects in search alongside posts and videos

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -107,7 +107,7 @@ function createTagCount(allBlogs, allProjects, allCommunities, allVideos) {
   writeFileSync('./src/app/tag-data.json', JSON.stringify(sortedTagCount, null, 2))
 }
 
-function createSearchIndex(allBlogs, allVideos) {
+function createSearchIndex(allBlogs, allVideos, allProjects) {
   if (
     siteMetadata?.search?.provider === 'kbar' &&
     siteMetadata.search.kbarConfig.searchDocumentsPath
@@ -115,7 +115,7 @@ function createSearchIndex(allBlogs, allVideos) {
     const publishedVideos = allVideos.filter((video) => !isProduction || video.draft !== true)
     writeFileSync(
       `public/${siteMetadata.search.kbarConfig.searchDocumentsPath}`,
-      JSON.stringify([...sortPosts(allBlogs), ...publishedVideos])
+      JSON.stringify([...sortPosts(allBlogs), ...publishedVideos, ...allProjects])
     )
     console.log('Local search index generated...')
   }
@@ -391,6 +391,6 @@ export default makeSource({
   onSuccess: async (importData) => {
     const { allBlogs, allProjects, allCommunities, allVideos } = await importData()
     createTagCount(allBlogs, allProjects, allCommunities, allVideos)
-    createSearchIndex(allBlogs, allVideos)
+    createSearchIndex(allBlogs, allVideos, allProjects)
   },
 })

--- a/src/components/SearchProvider.tsx
+++ b/src/components/SearchProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Blog, Video } from 'contentlayer2/generated'
+import { Blog, Project, Video } from 'contentlayer2/generated'
 import { useRouter } from 'next/navigation'
 import { KBarSearchProvider } from 'pliny/search/KBar'
 
@@ -29,7 +29,7 @@ export const SearchProvider = ({ children }) => {
           },
         ],
         onSearchDocumentsLoad(json) {
-          return json.map((item: Blog | Video) => {
+          return json.map((item: Blog | Video | Project) => {
             if (item.type === 'Video') {
               return {
                 id: item.url,
@@ -38,6 +38,19 @@ export const SearchProvider = ({ children }) => {
                 section: 'Video',
                 subtitle: item.tags?.join(', '),
                 perform: () => window.open(item.url, '_blank', 'noopener,noreferrer'),
+              }
+            }
+            if (item.type === 'Project') {
+              return {
+                id: item.slug,
+                name: item.title,
+                keywords: [item.description, item.tags?.join(' ')].filter(Boolean).join(' '),
+                section: 'Project',
+                subtitle: item.tags?.join(', '),
+                perform: () =>
+                  item.href
+                    ? window.open(item.href, '_blank', 'noopener,noreferrer')
+                    : router.push('/projects'),
               }
             }
             return {


### PR DESCRIPTION
Previously only Blog and Video documents were written to public/search.json
and the kbar provider only branched on those two types. Projects existed in
contentlayer but were invisible to search.

https://claude.ai/code/session_01DkZ6TDnJkCz413juNFEwUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects are now included in the search index, making them discoverable alongside blogs and videos. Project search results either open external links or navigate to the projects page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->