### PR TITLE
Add humanizer skill for removing AI-generated writing patterns

### DIFF
--- a/.claude/skills/humanizer/.claude-plugin/marketplace.json
+++ b/.claude/skills/humanizer/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
+  "name": "humanizer",
+  "owner": {
+    "name": "blader",
+    "url": "https://github.com/blader"
+  },
+  "description": "The humanizer skill, installable as a Claude Code plugin.",
+  "plugins": [
+    {
+      "name": "humanizer",
+      "source": "./",
+      "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
+      "license": "MIT",
+      "keywords": ["writing", "editing", "ai-detection", "humanize", "prose", "style"]
+    }
+  ]
+}

--- a/.claude/skills/humanizer/.claude-plugin/plugin.json
+++ b/.claude/skills/humanizer/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "humanizer",
+  "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
+  "version": "2.9.1",
+  "author": {
+    "name": "blader",
+    "url": "https://github.com/blader"
+  },
+  "homepage": "https://github.com/blader/humanizer",
+  "repository": "https://github.com/blader/humanizer",
+  "license": "MIT",
+  "keywords": ["writing", "editing", "ai-detection", "humanize", "prose", "style"]
+}

--- a/.claude/skills/humanizer/.github/workflows/validate.yml
+++ b/.claude/skills/humanizer/.github/workflows/validate.yml
@@ -1,0 +1,29 @@
+name: Validate package
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate synchronized package metadata
+        run: python3 scripts/validate-package.py
+      - name: Verify Agent Skills discovery
+        run: npx --yes skills@1.5.20 add . --list
+      - name: Validate Claude Code marketplace
+        run: |
+          npm install --global @anthropic-ai/claude-code
+          claude plugin validate .

--- a/.claude/skills/humanizer/AGENTS.md
+++ b/.claude/skills/humanizer/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Codex, Warp, etc.) working in this repository.
+
+## What this repo is
+
+A portable agent skill implemented entirely as Markdown. The runtime artifact is `SKILL.md`: the agent reads its YAML frontmatter and editor prompt. There is no build step, and the repo should avoid wording that limits support to one or two harnesses.
+
+## Key files
+
+- `SKILL.md` — the skill itself. Portable YAML frontmatter (`name`, `description`, `license`, `metadata.version`) followed by the canonical, numbered pattern list with before/after examples. **This is the source of truth.**
+- `README.md` — for humans: installation, usage, a summary table of the patterns, and a version history.
+- `.claude-plugin/plugin.json` — optional Claude Code plugin manifest.
+- `.claude-plugin/marketplace.json` — optional single-repo marketplace entry so `/plugin marketplace add blader/humanizer` works.
+- `scripts/validate-package.py` — dependency-free package and synchronization checks used locally and in CI.
+
+## The maintenance contract
+
+`SKILL.md` and `README.md` must stay in sync. When you change behavior or content:
+
+- **Patterns:** the skill currently defines **33 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
+- **Version:** `SKILL.md` frontmatter stores the version under `metadata.version`, `README.md` has a "Version History" section, and `.claude-plugin/plugin.json` has a `version` field. Bump them together so package metadata matches the skill. Keep the skill version under `metadata`; a top-level `version` key is not portable across Agent Skills hosts. (`marketplace.json` intentionally omits a version so `plugin.json` stays the package source of truth.)
+- **Compatibility:** keep install and usage language harness-neutral. The skill should work in any agent harness that can load Markdown skill instructions; Claude Code, OpenCode, Codex, and other harnesses are examples, not limits.
+- **Validation:** run `python3 scripts/validate-package.py`, `npx skills add . --list`, and `claude plugin validate .` before publishing.
+- **Non-obvious fixes:** if you change the prompt to handle a tricky failure mode (a repeated mis-edit, an unexpected tone shift), add a short note to the README version history explaining what was fixed and why.
+
+## Editing SKILL.md
+
+- Preserve valid YAML frontmatter (formatting and indentation).
+- The prompt below the frontmatter is the product. Edit it like a careful instruction document, not code.

--- a/.claude/skills/humanizer/LICENSE
+++ b/.claude/skills/humanizer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Siqi Chen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/humanizer/README.md
+++ b/.claude/skills/humanizer/README.md
@@ -1,0 +1,230 @@
+# Humanizer
+
+[![skills.sh installs](https://skills.sh/b/blader/humanizer)](https://skills.sh/blader/humanizer)
+
+A portable agent skill that removes signs of AI-generated writing from text, making it sound more natural and human. It is plain Markdown, so it can run in any harness that supports skill-style instructions.
+
+## Installation
+
+### Skills CLI
+
+Install globally with the cross-agent skills CLI so Humanizer is available in every project:
+
+```bash
+npx skills add blader/humanizer --global
+```
+
+Update an existing install:
+
+```bash
+npx skills update humanizer --global
+```
+
+To install globally into every supported agent harness:
+
+```bash
+npx skills add blader/humanizer --global --agent '*'
+```
+
+To target one configured harness, pass its agent name:
+
+```bash
+npx skills add blader/humanizer --global --agent <agent-name>
+```
+
+Omit `--global` for a project-local install that can be committed and shared with collaborators. Start a new agent session or reload skills after installation.
+
+### Claude Code plugin
+
+Claude Code users can also install Humanizer as a plugin:
+
+```
+/plugin marketplace add blader/humanizer
+/plugin install humanizer@humanizer
+```
+
+The skill is then invoked as `/humanizer:humanizer`.
+
+### Manual
+
+Any agent harness can use the skill directly because the runtime artifact is `SKILL.md`. Install it wherever your harness expects skill directories, or copy `SKILL.md` into an existing skill folder.
+
+For example:
+
+```bash
+git clone https://github.com/blader/humanizer.git /path/to/your/skills/humanizer
+```
+
+Or, if you already have this repo cloned:
+
+```bash
+mkdir -p /path/to/your/skills/humanizer
+cp SKILL.md /path/to/your/skills/humanizer/
+```
+
+## Usage
+
+Invoke the skill however your agent harness exposes installed skills. Common forms include a slash command or a direct request:
+
+```
+/humanizer
+
+[paste your text here]
+```
+
+```
+Please humanize this text: [your text]
+```
+
+Point it at a file and the skill rewrites it in place:
+
+```
+Humanize the prose in docs/launch-post.md
+```
+
+### Voice Calibration
+
+To match your personal writing style, provide a sample of your own writing:
+
+```
+/humanizer
+
+Here's a sample of my writing for voice matching:
+[paste 2-3 paragraphs of your own writing]
+
+Now humanize this text:
+[paste AI text to humanize]
+```
+
+The skill will analyze your sentence rhythm, word choices, and quirks, then apply them to the rewrite instead of producing generic "clean" output.
+
+## Overview
+
+Based on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) guide, maintained by WikiProject AI Cleanup. This comprehensive guide comes from observations of thousands of instances of AI-generated text.
+
+The skill also includes a final "obviously AI generated" audit pass and a second rewrite, to catch lingering AI-isms in the first draft.
+
+Rewrites follow a no-fabrication rule: they never add facts, names, dates, or citations that aren't in the source text. Specificity has to come from the source or the author, not from the rewrite.
+
+### Key Insight from Wikipedia
+
+> "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
+
+## 33 Patterns Detected (with Before/After Examples)
+
+### Content Patterns
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 1 | **Significance inflation** | "marking a pivotal moment in the evolution of..." | "was established in 1989 as part of a wider decentralization" |
+| 2 | **Notability name-dropping** | "cited in NYT, BBC, FT, and The Hindu" | Trim the list; keep only sourced context |
+| 3 | **Superficial -ing analyses** | "symbolizing... reflecting... showcasing..." | Remove, or keep only what the source supports |
+| 4 | **Promotional language** | "nestled within the breathtaking region" | "is a town in the Gonder region" |
+| 5 | **Vague attributions** | "Experts believe it plays a crucial role" | Name a real source or cut the claim |
+| 6 | **Formulaic challenges** | "Despite challenges... continues to thrive" | Keep the sourced facts; cut the boosterism |
+
+### Language Patterns
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 7 | **AI vocabulary** | "Actually... additionally... testament... landscape... showcasing" | "also... remain common" |
+| 8 | **Copula avoidance** | "serves as... features... boasts" | "is... has" |
+| 9 | **Negative parallelisms / tailing negations** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
+| 10 | **Rule of three** | "innovation, inspiration, and insights" | Use natural number of items |
+| 11 | **Synonym cycling** | "protagonist... main character... central figure... hero" | "protagonist" (repeat when clearest) |
+| 12 | **False ranges** | "from the Big Bang to dark matter" | List topics directly |
+| 13 | **Passive voice / subjectless fragments** | "No configuration file needed" | Name the actor when it helps clarity |
+
+### Style Patterns
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 14 | **Em/en dashes** | "institutions—not the people—yet this continues—" | Cut them: periods, commas, colons, or parentheses |
+| 15 | **Boldface overuse** | "**OKRs**, **KPIs**, **BMC**" | "OKRs, KPIs, BMC" |
+| 16 | **Inline-header lists** | "**Performance:** Performance improved" | Convert to prose |
+| 17 | **Title Case Headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
+| 18 | **Emojis** | "🚀 Launch Phase: 💡 Key Insight:" | Remove emojis |
+| 19 | **Curly quotes** | `said “the project”` | `said "the project"` |
+| 26 | **Hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Drop hyphens on common word pairs |
+| 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
+| 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
+| 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
+| 30 | **Diff-anchored writing** | "This function was added to replace..." | Describe what it does, not what changed |
+| 31 | **Manufactured punchlines / staccato drama** | "It had no preference. No prior. No nostalgia." | Use varied sentence lengths and concrete claims |
+| 32 | **Aphorism formulas** | "Symmetry is the language of trust" | Replace the formula with the actual claim |
+| 33 | **Conversational rhetorical openers** | "Honestly? It depends..." | Remove the fake-candid setup |
+
+### Communication Patterns
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 20 | **Chatbot artifacts** | "I hope this helps! Let me know if..." | Remove entirely |
+| 21 | **Cutoff disclaimers** | "While details are limited in available sources..." | Find sources or remove |
+| 22 | **Sycophantic tone** | "Great question! You're absolutely right!" | Respond directly |
+
+### Filler and Hedging
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 23 | **Filler phrases** | "In order to", "Due to the fact that" | "To", "Because" |
+| 24 | **Excessive hedging** | "could potentially possibly" | "may" |
+| 25 | **Generic conclusions** | "The future looks bright" | Specific plans or facts |
+
+## Full Example
+
+*(Illustration note: the rewrite below adds specifics, like the month and the neighborhoods, that stand in for details the author would supply. In a real session those come from the user; the skill asks rather than invents.)*
+
+**Before (AI-sounding):**
+> I recently spent five unforgettable days in Lisbon, and let me tell you — this city completely stole my heart. From the moment I arrived, I knew I was somewhere truly special.
+>
+> Nestled along the banks of the Tagus River, Lisbon stands as a vibrant testament to Portugal's enduring spirit, where rich history and modern energy intertwine at every turn. Yes, the famous hills are challenging — my legs certainly felt it! — but every climb rewards you with breathtaking, panoramic views that make it all worthwhile.
+>
+> No trip would be complete without riding the iconic Tram 28, winding through the city's most historic neighborhoods. And the food? Simply divine. The original pastéis de nata at Pastéis de Belém are a beloved national treasure, and savoring one still warm was a moment I will never forget.
+>
+> But what truly makes Lisbon special isn't just the sights — it's the feeling. Wander a few steps off the main squares and you'll discover a quieter, more authentic side: sun-drenched alleys, charming tiled facades, and friendly locals going about their daily lives, inviting you to slow down and savor every moment.
+>
+> Of course, the must-see São Jorge Castle offers stunning views over the rooftops below. The queues can be long, but the experience is absolutely worth it for any history buff or curious traveler.
+>
+> Would I go back? Absolutely. Lisbon isn't just a place to visit — it's a place to fall in love with, again and again. If you're dreaming of your next getaway, this is one destination that promises memories to last a lifetime. ✨
+
+**After (Humanized):**
+> I spent five days in Lisbon last October and still have mixed feelings about it. Beautiful, yes. Also harder on the knees than anyone warned me.
+>
+> The hills are the whole story and somehow never make the brochures. My hotel was up in Alfama, which photographs beautifully and translates, in practice, to climbing what felt like a six-story staircase every time I wanted coffee. By the second day my calves had opinions. I started planning each walk around which way was downhill, which is a strange way to see a city but probably an honest one.
+>
+> Everyone says to ride Tram 28, so I did, wedged against a stranger's backpack for forty minutes while three tour groups filmed the same corner. I would walk the route next time, or go before breakfast. The custard tarts, though, earn the fuss. I had one at a plain little place in Graça, still warm, and for about thirty seconds I understood why people build trips around pastry.
+>
+> What I did not expect was how quiet the city gets away from the main squares. Two blocks uphill from any plaza it turns into laundry lines, chipped tile, open windows, and old men watching football with the sound turned up. That is the Lisbon I keep thinking about, not the castle.
+>
+> The castle is fine. The view is great, the queue is long, and I spent more time shuffling toward the entrance than looking at anything once I got inside. If I had only two days, I would trade it for an afternoon of getting lost.
+>
+> I would go back, but in spring and with better shoes. Lisbon does not bend over backward to make things easy for you. I think I liked that, even when my legs disagreed.
+
+## References
+
+- [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - Primary source
+- [WikiProject AI Cleanup](https://en.wikipedia.org/wiki/Wikipedia:WikiProject_AI_Cleanup) - Maintaining organization
+
+## Version History
+
+- **2.9.1** - Improved distribution and portability: removed nonportable frontmatter and tool preapprovals, made global installation the documented default, added package validation, and removed the duplicated long-form example from the runtime prompt. No change to the 33 patterns.
+- **2.9.0** - Added a no-fabrication rule: rewrites may not invent facts, names, dates, or citations not present in the source, and every example that modeled invented specifics was re-cut to use only source information (fixes #187). Replaced paragraph-count parity with an information-over-shape rule, made a user's voice sample outrank the em dash ban, and added invocation modes (pasted text / file / embedded). No change to the 33 patterns.
+- **2.8.3** - Moved the skill version from the unsupported top-level frontmatter key to `metadata.version` for Agent Skills and Claude compatibility. No change to the 33 patterns.
+- **2.8.2** - Replaced the full before/after example with a first-person Lisbon trip recap. The after now keeps the same topic, perspective, and rough length as the before while removing the AI tells without becoming clipped or slogan-like. No change to the 33 patterns.
+- **2.8.1** - Added cross-agent installation docs, optional Claude Code plugin packaging, and a compact secondhand-text false-positive guard. No change to the 33 patterns.
+- **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
+- **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
+- **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.
+- **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns
+- **2.5.0** - Added patterns for persuasive framing, signposting, and fragmented headers; expanded negative parallelisms to cover tailing negations; tightened wording around em dash overuse; fixed frontmatter wording to use "filler phrases"
+- **2.4.0** - Added voice calibration: match the user's personal writing style from samples
+- **2.3.0** - Added pattern #25: hyphenated word pair overuse
+- **2.2.0** - Added a final "obviously AI generated" audit + second-pass rewrite prompts
+- **2.1.1** - Fixed pattern #18 example (curly quotes vs straight quotes)
+- **2.1.0** - Added before/after examples for all 24 patterns
+- **2.0.0** - Complete rewrite based on raw Wikipedia article content
+- **1.0.0** - Initial release
+
+## License
+
+MIT

--- a/.claude/skills/humanizer/SKILL.md
+++ b/.claude/skills/humanizer/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: humanizer
+description: |
+  Remove signs of AI-generated writing from text. Use when editing or reviewing
+  text to make it sound more natural and human-written. Based on Wikipedia's
+  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
+  inflated symbolism, promotional language, superficial -ing analyses, vague
+  attributions, em dash overuse, rule of three, AI vocabulary words, passive
+  voice, negative parallelisms, and filler phrases.
+license: MIT
+metadata:
+  version: "2.9.1"
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the patterns listed below.
+2. **Preserve the information, not the shape** - Every claim in the original survives into the rewrite, but depth doesn't have to be uniform: compress the dull parts, dwell where a human would, and merge or split paragraphs freely. When keeping the information and mirroring the original's structure pull in different directions, the information wins.
+3. **Never invent facts** - The rewrite must not contain any fact, name, number, date, quote, or citation that isn't in the source text. Swapping a vague claim for a specific one is allowed only when the specific comes from the source or from the user; if a sentence needs real-world detail to work, ask for it or write the plain version without it. Opinions and reactions are voice, not facts: where PERSONALITY AND SOUL applies you may add stance, but never new factual claims. (In fiction, invented detail is the job. This rule governs everything else.)
+4. **Match the voice** - Fit the intended tone (formal, casual, technical). Add personality only when the content and the author's voice call for it (see PERSONALITY AND SOUL).
+
+How you're invoked changes what you deliver (see Invocation Modes). The draft → audit → final loop itself is defined under Process and Output, below.
+
+## Voice Calibration
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. Read the sample first. Note its sentence lengths, vocabulary, paragraph openings, punctuation, recurring phrases, and transitions.
+2. Match those habits instead of merely deleting AI patterns. Do not upgrade casual words or regularize deliberate quirks.
+3. Without a sample, use the default behavior below.
+
+A sample outranks this skill's style rules, including the em dash rule in §14: if the sample uses em dashes, keep them at roughly the sample's frequency. Matching the author beats scrubbing the tell.
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+**Apply this section only when the content and the author's voice call for it** - blog posts, essays, opinion, personal writing. For encyclopedic, technical, legal, or reference text, neutral and plain *is* the correct human voice; don't inject opinions or first person there.
+
+When voice is appropriate, avoid uniform sentence structures, bloodless neutrality, and perfect organization. Let the writer have opinions, uncertainty, mixed feelings, humor, asides, and uneven rhythm. Never add factual claims to create that personality.
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+**After:**
+> The Statistical Institute of Catalonia was established in 1989, part of a wider decentralization of administrative functions in Spain.
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+**After:**
+> Her views have been cited in The New York Times and the BBC.
+
+(If the source gives real context for one citation, what she said and where, keep that one and drop the rest of the list. Don't invent the context to make the trimmed version sound better.)
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+**After:**
+> The temple is painted blue, green, and gold, colors meant to evoke Texas bluebonnets and the Gulf of Mexico.
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia.
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+**After:**
+> Researchers and conservationists study the Haolai River for its unusual characteristics.
+
+(If a real source exists, name it. Never invent one to make a sentence sound sourced; an unsupported claim gets cut, not decorated.)
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+**After:**
+> Korattur has recurring traffic congestion and water shortages.
+
+(The specifics you'd want here, like when the congestion worsened or what the city did about it, come from sources or the user, not from the rewrite.)
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+### 9. Negative Parallelisms and Tailing Negations
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+**After:**
+> The heavy beat adds to the aggressive tone.
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+### 10. Rule of Three Overuse
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+### 11. Elegant Variation (Synonym Cycling)
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+### 12. False Ranges
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+### 13. Passive Voice and Subjectless Fragments
+**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+## STYLE PATTERNS
+
+### 14. Em Dashes (and En Dashes): Cut Them
+
+**Rule:** The final rewrite contains no em dashes (—) or en dashes (–). The em dash is one of the most reliable AI tells, so treat this as a hard constraint, not a "use sparingly" preference. Replace each one, in rough order of preference: a period (start a new sentence), a comma (a tight aside), a colon (introducing an explanation), parentheses (a true aside), or restructure the sentence. Also catch spaced em dashes (` — `) and double hyphens (` -- `) used the same way.
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+**Before:**
+> The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
+**After:**
+> The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
+
+Before returning the final rewrite, scan it for `—` and `–`. Any hit means the draft isn't done. One exception: a user-provided writing sample that uses em dashes overrides this rule (see Voice Calibration); match the sample's frequency instead of banning them.
+
+### 15. Overuse of Boldface
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+### 16. Inline-Header Vertical Lists
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+### 17. Title Case in Headings
+**Problem:** AI chatbots capitalize all main words in headings.
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+**After:**
+> ## Strategic negotiations and global partnerships
+
+### 18. Emojis
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+### 19. Curly Quotation Marks
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
+**Before:**
+> He said “the project is on track” but others disagreed.
+**After:**
+> He said "the project is on track" but others disagreed.
+
+## COMMUNICATION PATTERNS
+
+### 20. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., Want me to...?, Want me to give examples?, Should I continue?, let me know, here is a...
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+### 21. Knowledge-Cutoff Disclaimers and Speculative Gap-Filling
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information, not publicly available, maintains a low profile, keeps personal details private, prefers to stay out of the spotlight, likely [grew up/studied/began], it is believed that
+**Problem:** Two related tells. (a) Older models leave hard knowledge-cutoff disclaimers in the text. (b) When a model can't find a source, it writes a paragraph *about* not finding one and then invents plausible filler to cover the gap. For a private person the guess almost always lands on the same stock phrases ("maintains a low profile," "keeps personal details private"), none of it sourced. Say what isn't known, or cut the sentence; don't dress a guess up as fact.
+**Before (cutoff disclaimer):**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+**After:**
+> The company's founding date is not documented in the available sources. (Or cut the sentence. State a date only if a source provides one.)
+**Before (speculative gap-fill):**
+> Information about her early life is not publicly available, suggesting she maintains a low profile and keeps personal details private. She likely grew up in a middle-class household, which shaped her later interest in education reform.
+**After:**
+> Her early life is not documented in the available sources. (Or omit the section.)
+
+### 22. Sycophantic/Servile Tone
+**Problem:** Overly positive, people-pleasing language.
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+**After:**
+> The economic factors you mentioned are relevant here.
+
+## FILLER AND HEDGING
+
+### 23. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+### 24. Excessive Hedging
+**Problem:** Over-qualifying statements.
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+**After:**
+> The policy may affect outcomes.
+
+### 25. Generic Positive Conclusions
+**Problem:** Vague upbeat endings.
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+**After:**
+> (Cut the paragraph. End on the last concrete fact instead of a send-off. If the source states real plans, use those.)
+
+### 26. Hyphenated Word Pair Overuse
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+**Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
+**After:**
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
+
+### 27. Persuasive Authority Tropes
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+### 28. Signposting and Announcements
+
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
+**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
+**Before:**
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+
+### 29. Fragmented Headers
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.
+
+### 30. Diff-Anchored Writing
+**Problem:** Documentation or comments written as if narrating a change rather than describing the thing as it is. Unless the document is inherently version-scoped (changelogs, release notes, migration guides), it should read coherently without knowing what changed in the last commit.
+**Before:**
+> This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
+**After:**
+> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+### 31. Manufactured Punchlines and Staccato Drama
+**Problem:** LLMs often make every sentence land like a quotable closer, then stack short declarative fragments to manufacture drama. A single short sentence for emphasis is fine; a run of them starts to sound engineered.
+**Before:**
+> Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
+**After:**
+> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
+
+### 32. Aphorism Formulas
+
+**Words to watch:** X is the Y of Z, X becomes a trap, X is not a tool but a mirror, the language of, the currency of, the architecture of
+**Problem:** LLMs turn ordinary claims into reusable aphorisms that sound profound without adding precision. Replace the formula with the concrete claim it is gesturing at.
+**Before:**
+> Symmetry is the language of trust. Efficiency becomes a trap when teams forget the human layer.
+**After:**
+> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
+
+### 33. Conversational Rhetorical Openers
+
+**Phrases to watch:** Honestly?, Look, Here's the thing, The thing is, Let's be honest, Real talk, when used as standalone hooks or fake-candid pauses before an ordinary point.
+**Problem:** LLMs open with a fake-candid hook to manufacture intimacy before delivering a routine claim. The tell is the theatrical pause-and-reveal: a one-word question or aside, then the "real" answer. A person being honest usually just says the thing.
+**Before:**
+> Is it worth the price? Honestly? It depends on how often you'll use it.
+**After:**
+> Whether it's worth the price depends on how often you'll use it.
+
+## DETECTION GUIDANCE
+
+### What NOT to flag (false positives)
+
+A clean human writer can hit several of the patterns above without any AI involvement. Before rewriting, sanity-check that you are not gutting legitimate prose. The following are *not* reliable indicators on their own:
+
+- **Perfect grammar and consistent style.** Many writers are professionals or have been edited. Polish does not equal AI.
+- **Mixed casual and formal registers.** This often signals a person in a technical field, a young writer, or someone with neurodivergent prose habits — not a chatbot.
+- **"Bland" or "robotic" prose.** AI prose has *specific* tells. Generic dryness without those tells is just dry writing.
+- **Formal or academic vocabulary.** AI overuses *specific* fancy words (see §7), not all fancy words. Don't flatten "ostensibly" or "constituent" just because they sound brainy.
+- **Letter-style opening or closing on a comment.** Salutations and sign-offs predate ChatGPT by centuries.
+- **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
+- **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
+- **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
+- **One short emphatic sentence.** Humans use clipped sentences to land a point. Flag staccato drama only when several short fragments appear in a row and inflate the tone.
+- **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
+- **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
+- **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
+- **Secondhand text.** Do not rewrite watched phrases inside quotations, titles, proper names, or examples where the phrase is being discussed rather than used.
+
+When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus *vibrant tapestry* plus a "Conclusion" section is a confession.
+
+### Signs of human writing (preserve these)
+
+When you see these, lean toward leaving the prose alone — they are evidence of a real person writing, and over-editing will destroy what makes the piece sound human:
+
+- **Specific, unusual, hard-to-fabricate detail.** A real address. A weird quote. The phrase "the lawyer who used to work upstairs from my dentist." LLMs round off specifics; humans hoard them.
+- **Mixed feelings and unresolved tension.** "I think this is mostly good, but it bothers me, and I can't fully explain why." LLMs default to clean takes.
+- **Dated, era-bound references.** Slang, memes, or in-jokes that map to a specific year and subculture. Models lag by a year or more.
+- **First-person editorial choices the writer can defend.** If the writer can explain *why* they made a particular cut or used a particular word, that's a strong human signal.
+- **Variety in sentence length.** Real writing alternates short and long. AI writing tends toward an even, mid-length cadence.
+- **Genuine asides, parentheticals, or self-corrections.** "(I keep wanting to say 'almost' here, but it really was certain.)" Models rarely interrupt themselves like this.
+- **Edits made before November 30, 2022.** ChatGPT's public launch. Anything older than that is, with very rare exceptions, not AI-written.
+
+---
+
+## Invocation Modes
+
+**Pasted text (default).** The user gives text in the conversation. Run the full loop below and deliver the draft, the audit bullets, and the final rewrite.
+
+**File mode.** The user points at a file. Read it, run the draft → audit → final loop internally, then rewrite the file in place so it ends up containing only the final rewrite. Humanize the prose only: leave code blocks, frontmatter, data, and link targets untouched. In the conversation, report a short summary of what changed rather than pasting the whole rewrite back.
+
+**Embedded mode.** Another task or agent is using this skill as one step of a larger job (a PR description, a commit message, a doc). Run the loop internally and output only the final text. No draft, no audit bullets, no summary. The caller wants prose, not ceremony.
+
+## Process and Output
+
+1. Read the input carefully and identify every instance of the patterns above.
+2. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register.
+3. Ask two questions: **"What makes the below so obviously AI generated?"** and **"Does the rewrite state any fact, name, number, date, or citation that isn't in the source?"** Answer briefly. A fabrication is a defect even when it sounds more human than the vague original.
+4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14).
+
+In pasted-text mode, deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes. In file and embedded modes, run the same loop but deliver only what the mode calls for (see Invocation Modes).
+
+## Reference
+
+This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/.claude/skills/humanizer/agents/openai.yaml
+++ b/.claude/skills/humanizer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Humanizer"
+  short_description: "Remove AI writing patterns from prose"
+  default_prompt: "Use $humanizer to make this text sound natural while preserving its meaning and facts."

--- a/.claude/skills/humanizer/scripts/validate-package.py
+++ b/.claude/skills/humanizer/scripts/validate-package.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate Humanizer's portable package surfaces without external dependencies."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL = (ROOT / "SKILL.md").read_text()
+README = (ROOT / "README.md").read_text()
+PLUGIN = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text())
+
+
+def require(match: re.Match[str] | None, message: str) -> re.Match[str]:
+    if match is None:
+        raise SystemExit(message)
+    return match
+
+
+frontmatter = require(
+    re.match(r"\A---\n(.*?)\n---\n", SKILL, re.DOTALL),
+    "SKILL.md must start with YAML frontmatter",
+).group(1)
+
+for nonportable_key in ("compatibility:", "allowed-tools:"):
+    if re.search(rf"(?m)^{re.escape(nonportable_key)}", frontmatter):
+        raise SystemExit(f"Remove nonportable frontmatter key: {nonportable_key[:-1]}")
+
+skill_version = require(
+    re.search(r'(?m)^\s+version:\s*["\']([^"\']+)["\']\s*$', frontmatter),
+    "SKILL.md metadata.version is missing",
+).group(1)
+readme_version = require(
+    re.search(r"(?m)^- \*\*([0-9]+\.[0-9]+\.[0-9]+)\*\*", README),
+    "README version history is missing",
+).group(1)
+
+versions = {skill_version, readme_version, str(PLUGIN.get("version", ""))}
+if len(versions) != 1:
+    raise SystemExit(f"Version mismatch: {sorted(versions)}")
+
+pattern_numbers = [
+    int(number)
+    for number in re.findall(r"(?m)^### ([0-9]+)\. ", SKILL)
+]
+if pattern_numbers != list(range(1, 34)):
+    raise SystemExit(f"Expected patterns 1-33, found {pattern_numbers}")
+
+readme_numbers = {
+    int(number) for number in re.findall(r"(?m)^\| ([0-9]+) \|", README)
+}
+if readme_numbers != set(range(1, 34)):
+    raise SystemExit("README pattern table must contain patterns 1-33")
+
+if len(SKILL.splitlines()) > 500:
+    raise SystemExit("SKILL.md exceeds the 500-line portability budget")
+
+print(f"Humanizer package v{skill_version} is valid")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,5 @@ when relevant:
   editing UI, styles, or content.
 - **n8n-masking** — mask sensitive data in n8n workflow JSON before sharing it
   publicly.
+- **humanizer** — remove signs of AI-generated writing from text, based on
+  Wikipedia's "Signs of AI writing" guide.


### PR DESCRIPTION
Adds a portable agent skill that detects and removes signs of AI-generated text, making writing sound more natural and human. The skill is based on Wikipedia's comprehensive "Signs of AI writing" guide and identifies 33 distinct patterns across content, language, style, communication, and filler categories.

## Key changes

- **SKILL.md** — The core skill implementation (412 lines) with:
  - 33 numbered patterns organized into 5 categories (content, language, style, communication, filler/hedging)
  - Before/after examples for each pattern
  - Voice calibration guidance to match user writing samples
  - A no-fabrication rule ensuring rewrites never invent facts, names, dates, or citations
  - Detection guidance and false-positive warnings

- **README.md** — User-facing documentation including:
  - Installation instructions for Skills CLI, Claude Code plugin, and manual setup
  - Usage examples and voice calibration workflow
  - Compact summary table of all 33 patterns
  - Full before/after example (Lisbon travel post)
  - Version history tracking evolution from 2.1.0 to 2.9.1

- **Package infrastructure**:
  - `scripts/validate-package.py` — Dependency-free validation ensuring SKILL.md/README/plugin.json version sync, pattern numbering (1–33), and portability constraints
  - `.claude-plugin/plugin.json` — Claude Code plugin manifest
  - `.claude-plugin/marketplace.json` — Marketplace discovery entry
  - `agents/openai.yaml` — Agent harness configuration
  - `.github/workflows/validate.yml` — CI validation pipeline
  - `AGENTS.md` — Maintenance contract and repo structure guidance
  - `LICENSE` — MIT license

- **CLAUDE.md** — Updated project skills list to reference humanizer

## Notable implementation details

- The skill is entirely portable Markdown with no build step; SKILL.md is the runtime artifact
- Frontmatter uses only portable keys (`name`, `description`, `license`, `metadata.version`); nonportable keys like `compatibility` and `allowed-tools` are explicitly excluded
- Voice calibration allows users to provide writing samples so the skill matches their personal style instead of producing generic output
- The no-fabrication rule is enforced throughout: rewrites preserve all facts from the source but never invent specifics to make sentences sound better
- Package validation is strict: version must match across SKILL.md, README, and plugin.json; patterns must be numbered 1–33; SKILL.md must stay under 500 lines for portability

https://claude.ai/code/session_01C1PRarA4oP7htuoHBQCyXR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Humanizer writing skill for identifying and removing common AI-writing patterns while preserving factual content and intended voice.
  - Supports pasted text, files, and voice samples, with draft, audit, and final-rewrite workflows.
  - Added integrations for Claude Code, Agent Skills, and OpenAI-compatible agent configurations.
- **Documentation**
  - Added installation instructions, usage examples, pattern references, rewrite examples, licensing, and version history.
- **Chores**
  - Added automated package validation for metadata, documentation coverage, compatibility, and skill discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->